### PR TITLE
Updated es.ini

### DIFF
--- a/src/es.ini
+++ b/src/es.ini
@@ -1,5 +1,5 @@
 # Aseprite
-# Copyright (C) 2018-2020  Igara Studio S.A.
+# Copyright (C) 2018-2022  Igara Studio S.A.
 # Copyright (C) 2016-2018  David Capello
 
 [advanced_mode]
@@ -77,11 +77,11 @@ Advertencia
 END
 file_format_alpha_channel = Canal alfa
 file_format_tags = Etiquetas
-file_format_frames = Fotogramas
+file_format_frames = Frames
 file_format_grayscale_mode = Modo escala de grises
 file_format_indexed_mode = Modo indexado
 file_format_layers = Capas
-file_format_palette_changes = Cambios de paleta entre fotogramas
+file_format_palette_changes = Cambios de paleta entre frames
 file_format_rgb_mode = Modo RGB
 invalid_chars_in_filename = <<<END
 Error
@@ -178,7 +178,7 @@ Advertencia al Exportar
 END
 
 [brush_slot_params]
-brush = Pincel:
+brush = Brocha:
 brush_type = Tipo
 brush_size = Tamaño
 brush_angle = Ángulo
@@ -211,15 +211,15 @@ AddColor_Foreground = Primario
 AddColor_Specific = Específico
 AdvancedMode = Modo Avanzado
 AutocropSprite = Recortar Sprite
-AutocropSprite_ByGrid = Recortar Sprite por Cuadrícula
+AutocropSprite_ByGrid = Recortar Sprite por Grilla
 BackgroundFromLayer = Fondo desde Capa
 BrightnessContrast = Ajustar Brillo/Contraste
 Cancel = Cancelar Operación Actual
 CanvasSize = Tamaño de Lienzo
 CelOpacity = Establecer Opacidad de Celda a {0} ({1}%)
 CelPropiedades = Propiedades de Celda
-ChangeBrush = Cambiar Pincel: {0}
-ChangeBrush_CustomBrush = Pincel Personalizado #{0}
+ChangeBrush = Cambiar Brocha: {0}
+ChangeBrush_CustomBrush = Brocha Personalizado #{0}
 ChangeBrush_DecrementAngle = Decrementar Ángulo
 ChangeBrush_DecrementSize = Decrementar Tamaño
 ChangeBrush_IncrementAngle = Incrementar Ángulo
@@ -257,7 +257,7 @@ Cut = Cortar
 DeselectMask = Deseleccionar Máscara
 Despeckle = Eliminar motas
 DeveloperConsole = Consola de Desarrollador
-DiscardBrush = Descartar Pincel
+DiscardBrush = Descartar Brocha
 DuplicateLayer = Duplicar Capa
 DuplicateSprite = Duplicar Sprite
 DuplicateView = Duplicar Vista
@@ -273,23 +273,23 @@ Flip_Canvas = Lienzo
 Flip_Horizontally = Horizontalmente
 Flip_Selection = Selección
 Flip_Vertically = Verticalmente
-CuadroPropiedades = Propiedades del Fotograma
-CuadroTagPropiedades = Propiedades de la Etiqueta
+FrameProperties = Propiedades de Frames
+FrameTagProperties = Propiedades de la Etiqueta
 FullscreenPreview = Vista Previa a Pantalla Completa
-GotoFirstCuadro = Ir al Primer Fotograma
-GotoFirstCuadroInTag = Ir al Primer Fotograma En Etiqueta
-GotoCuadro = Ir al Fotograma
-GotoLastCuadro = Ir al Último Fotograma
-GotoLastCuadroInTag = Ir al Último Fotograma En Etiqueta
-GotoNextCuadro = Ir al Siguiente Fotograma
-GotoNextCuadroWithSameTag = Ir al Fotograma con la misma etiqueta
+GotoFirstFrame = Ir al Primer Frame
+GotoFirstFrameInTag = Ir al Primer Frame En Etiqueta
+GotoFrame = Ir al Frame
+GotoLastFrame = Ir al Último Frame
+GotoLastFrameInTag = Ir al Último Frame En Etiqueta
+GotoNextFrame = Ir al Siguiente Frame
+GotoNextFrameWithSameTag = Ir al Frame con la misma etiqueta
 GotoNextLayer = Ir a la Siguiente Capa
 GotoNextTab = Ir a la Siguiente Pestaña
-GotoPreviousCuadro = Ir al Fotograma Anterior
-GotoPreviousCuadroWithSameTag = Ir al Fotograma Anterior con la misma etiqueta
+GotoPreviousFrame = Ir al Frame Anterior
+GotoPreviousFrameWithSameTag = Ir al Frame Anterior con la misma etiqueta
 GotoPreviousLayer = Ir a la Capa Anterior
 GotoPreviousTab = Ir a la Pestaña Anterior
-GridSettings = Ajustes de Cuadrícula
+GridSettings = Ajustes de Grilla
 Home = Inicio
 HueSaturation = Ajustar Matiz/Saturación
 ImportSpriteSheet = Importar Hoja de Sprites
@@ -333,15 +333,15 @@ MoveColors = Mover Colores
 MoveMask = Mover {0} {1}
 MoveMask_Boundaries = Seleccionar Límites
 MoveMask_Content = Seleccionar Contenido
-NewBrush = Crear Pincel
+NewBrush = Crear Brocha
 NewFile = Crear Archivo
 NewFile_FromClipboard = Crear Archivo desde Portapapeles
-NewCuadro = Crear Fotograma
-NewCuadro_NewEmptyCuadro = Crear Fotograma Vacío
-NewCuadro_DuplicateCels = Duplicar Celdas con Modo Capas
-NewCuadro_DuplicateCelsCopies = Duplicar Celdas
-NewCuadro_DuplicateCelsLinked = Duplicar Celdas Enlazadas
-NewCuadroTag = Crear Etiqueta
+NewFrame = Crear Frame
+NewFrame_NewEmptyFrame = Crear Frame Vacío
+NewFrame_DuplicateCels = Duplicar Celdas con Modo Capas
+NewFrame_DuplicateCelsCopies = Duplicar Celdas
+NewFrame_DuplicateCelsLinked = Duplicar Celdas Enlazadas
+NewFrameTag = Crear Etiqueta
 NewLayer = Crear {}
 NewLayer_BeforeActiveLayer = Crear {} Abajo
 NewLayer_Layer = Capa
@@ -375,31 +375,19 @@ PaletteSize = Tamaño de Paleta
 Paste = Pegar
 PasteText = Insertar Texto
 PixelPerfectMode = Cambiar a Modo Pixel Perfect
-PlayAnimación = Reproducir Animación
-PlayPreviewAnimación = Reproducir Previsualización de Animación
+PlayAnimation = Reproducir Animación
+PlayPreviewAnimation = Reproducir Previsualización de Animación
 Redo = Rehacer
 Refresh = Refrescar
-RemoveCuadro = Eliminar Fotograma
-RemoveCuadroTag = Eliminar Etiqueta
+RemoveFrame = Eliminar Frame
+RemoveFrameTag = Eliminar Etiqueta
 RemoveLayer = Eliminar Capa
-RemoveSlice = Eliminar Sector
-PaletteSize = Tamaño de Paleta
-Paste = Pegar
-PasteText = Insertar Texto
-PixelPerfectMode = Cambiar a Modo Pixel Perfect
-PlayAnimación = Reproducir Animación
-PlayPreviewAnimación = Reproducir Previsualización de Animación
-Redo = Rehacer
-Refresh = Refrescar
-RemoveCuadro = Eliminar Fotograma
-RemoveCuadroTag = Eliminar Etiqueta
-RemoveLayer = Eliminar Capa
-RemoveSlice = Eliminar Sector
+RemoveSlice = Eliminar Recorte
 ReopenClosedFile = Re-Abrir Archivo sin guardar
-RepeatLastExport = Repetir ultima exportación
+RepeatLastExport = Repetir última exportación
 ReplaceColor = Reemplazar Color
-ReselectMask = Reemplazar Mascara
-ReverseCuadros = Invertir Cuadros
+ReselectMask = Reseleccionar Máscara
+ReverseFrames = Frames en Reversa
 Rotate = Rotar {0} {1}
 Rotate_Selection = Rotar Selección
 Rotate_Sprite = Rotar Sprite
@@ -407,7 +395,7 @@ RunScript = Ejecutar Script
 SaveFile = Guardar Archivo
 SaveFileAs = Guardar Archivo Como
 SaveFileCopyAs = Exportar
-SaveMask = Guardar Mascara
+SaveMask = Guardar Máscara
 SavePalette = Guardar Paleta
 Screenshot = Capturar Pantalla
 Screenshot_Open = Capturar Pantalla y Abrir Captura
@@ -417,49 +405,49 @@ Screenshot_sRGB = (Perfil de Color sRGB)
 Screenshot_DisplayCS = (Perfil de Color de Pantalla)
 Scroll = Desplazar {0}
 ScrollCenter = Desplazar al centro de la Pantalla
-SelectTile = Seleccionar Cuadro
-SelectTile_Add = Seleccionar Cuadro (Agregar)
-SelectTile_Subtract = Seleccionar Cuadro (Sustraer)
-SelectTile_Intersect = Seleccionar Cuadro (Cruzar)
-SelectionAsGrid = Seleccion como Grilla
+SelectTile = Seleccionar Tile
+SelectTile_Add = Seleccionar Tile (Agregar)
+SelectTile_Subtract = Seleccionar Tile (Sustraer)
+SelectTile_Intersect = Seleccionar Tile (Cruzar)
+SelectionAsGrid = Selección como Grilla
 SetColorSelector = Configurar Selector de Colores
-SetColorSelector_Spectrum = Espectro de Colores
-SetColorSelector_TintShadeTone = Tinte/Sombra/Tono de Color
-SetColorSelector_RGBWheel = Rueda de Color RGB
-SetColorSelector_RYBWheel = Rueda de Color RYB
-SetColorSelector_NormalMapWheel = Rueda de Color de Mapeado Normal
+SetColorSelector_Spectrum = Configurar Espectro de Colores
+SetColorSelector_TintShadeTone = Configurar Tinte/Sombra/Tono de Color
+SetColorSelector_RGBWheel = Configurar Rueda de Color RGB
+SetColorSelector_RYBWheel = Configurar Rueda de Color RYB
+SetColorSelector_NormalMapWheel = Configurar Rueda de Color de Mapeado Normal
 SetInkType = Configurar Tipo de Tinta {0}
 SetLoopSection = Configurar Sección de Bucle
 SetPalette = Configurar Paleta
-SetPaletteEntrySize = Configurar Tamaño de Entrada de Ealeta
+SetPaletteEntrySize = Configurar Tamaño de Entrada de Paleta
 SetSameInk = Misma Tinta en las Herramientas
-ShowAutoGuides = Mostrar Auto-Guias
+ShowAutoGuides = Mostrar Auto-Guías
 ShowBrushPreview = Mostrar Previsualización de Brocha
 ShowBrushes = Mostrar Brochas
-ShowDynamics = Mostrar Dinamicos
+ShowDynamics = Mostrar Dinámicas
 ShowExtras = Mostrar Extras
 ShowGrid = Mostrar Grilla
-ShowLayerEdges = Mostrar Esquinas de la Capa
+ShowLayerEdges = Mostrar Bordes de la Capa
 ShowOnionSkin = Mostrar Piel de Cebolla
 ShowPaletteOptions = Mostrar Opciones de Paletas
-ShowPalettePresets = Mostrar Preajustes de Paletas
+ShowPalettePresets = Mostrar Sets de Paletas
 ShowPaletteSortOptions = Mostrar Opciones de Orden de Paletas
 ShowPixelGrid = Mostrar Grilla de Pixeles
-ShowSelectionEdges = Mostrar Esquinas de Selección
-ShowSlices = Mostrar Trozos
-SliceProperties = Propiedades de los Trozos
+ShowSelectionEdges = Mostrar Bordes de Selección
+ShowSlices = Mostrar Recortes
+SliceProperties = Propiedades de los Recortes
 SnapToGrid = Encajar en la Grilla
 SpriteProperties = Propiedades del Sprite
 SpriteSize = Tamaño del Sprite
 Stroke = Bordes de selección de trazos con el color de primer plano
-SwitchColors = Cambiar Colores
+SwitchColors = Intercambiar Colores
 SwapCheckerboardColors = Intercambiar los colores del fondo transparente
 SwitchNonactiveLayersOpacity = Cambiar la opacidad de las capas no activas
-SymmetryMode = Modo Simetria
-TiledMode = Modo Cuadricula
-Timeline = Activar/Desactivar Linea de Tiempo
+SymmetryMode = Modo Simetría
+TiledMode = Modo Tile
+Timeline = Activar/Desactivar Timeline
 TogglePreview = Activar/Desactivar Previsualización
-ToggleTimelineThumbnails = Activar/Desactivar Miniaturas en la Linea de Tiempo
+ToggleTimelineThumbnails = Activar/Desactivar Miniaturas en la Timeline
 Undo = Deshacer
 UndoHistory = Deshacer Historial
 UnlinkCel = Desvincular Celda
@@ -474,9 +462,9 @@ open_with_os = &Abrir con SO
 open_in_folder = Abrir en &Carpeta
 
 [canvas_size]
-title = Tamaño del Canvas
+title = Tamaño del Lienzo
 size = Tamaño:
-width = Anchura:
+width = Ancho:
 height = Altura:
 borders = Bordes:
 left = Izquierda:
@@ -506,7 +494,7 @@ queden fuera del nuevo tamaño del lienzo.
 END
 
 [cel_properties]
-title = Prpiedades de Celdas
+title = Propiedades de Cel
 opacity = Opacidad:
 user_data_tooltip = Datos del Usuario
 
@@ -527,7 +515,7 @@ flatten = Fusionar Capas
 reload_stock = &Recargar Stock
 
 [despeckle]
-width = Anchura:
+width = Ancho:
 height = Altura:
 
 [duplicate_sprite]
@@ -537,16 +525,16 @@ as = Como:
 merged_layers = Duplicar solo Capas Fusionadas
 
 [dynamics]
-pressure = Presióm
-pressure_tooltip = Controlar Paramentros de Presion desde el sensor del Lapiz
+pressure = Presión
+pressure_tooltip = Controlar Parámentros de Presión desde el sensor del Lápiz
 velocity = Velocidad
-velocity_tooltip = Controlar Parametros de Velocidad desde el Mouse
+velocity_tooltip = Controlar Parámetros de Velocidad desde el Mouse
 size = Tamaño
 size_tooltip = <<<END
 Cambia el tamaño del cepillo
 en función del valor del sensor
 END
-angle = Angulo
+angle = Ángulo
 angle_tooltip = <<<END
 Cambiar el ángulo del cepillo
 en función del valor del sensor
@@ -568,12 +556,12 @@ title = Exportar Archivo
 output_file = Archivo de Salida:
 resize = Redimensionar:
 layers = Capas:
-frames = Cuadros:
+frames = Frames:
 anidir = Dirección de Animación:
 pixel_ratio = Aplicar Ratio de Pixeles
-for_twitter = Exportar a Twitter
+for_twitter = Exportar para Twitter
 for_twitter_tooltip = <<<END
-Ajuste la duración del último cuadro a 1/4 para que
+Ajuste la duración del último frame a 1/4 para que
 Twitter reproduzca la animación correctamente.
 END
 adjust_resize = Ajustar Redimensionado a {0}%
@@ -597,72 +585,72 @@ output = Salida
 output_tooltip = Dónde guardar la hoja de sprites
 sheet_type = Tipo de hoja:
 sheet_type_tooltip = <<<END
-Indica una forma específica de maquetar los sprites en la hoja de sprites: 
-* Horizontal: Cada cuadro uno al lado del otro. 
-* Vertical: Cada cuadro uno debajo del otro. 
-* Por filas: Crea una fila para cada capa o etiqueta. 
-* Por columnas: Crear una columna para cada capa o etiqueta. 
+Indica una forma específica de ordenar los sprites en la hoja de sprites: 
+* Horizontal: Cada frame uno al lado del otro. 
+* Vertical: Cada frame uno debajo del otro. 
+* Por Filas: Crea una fila para cada capa o etiqueta. 
+* Por Columnas: Crear una columna para cada capa o etiqueta. 
 * Empaquetado: Trata de encajar todos los marcos de la mejor manera posible.
 END
-type_horz = Banda horizontal
-type_vert = Banda vertical
+type_horz = Banda Horizontal
+type_vert = Banda Vertical
 type_rows = Por Filas
-type_cols = Por columnas
-type_pack = Tipo de Paquete
+type_cols = Por Columnas
+type_pack = Enpaquetado
 constraints = Restricciones:
 constraints_tooltip = <<<END
 Restricciones especiales para la hoja de sprites.  
 Por ejemplo, número fijo de filas/columnas o número fijo de píxeles (ancho/alto).
 END
 constraint_fixed_none = Ninguno
-constraint_fixed_cols = Arreglar # of Columns
-constraint_fixed_rows = Arreglar # of Rows
-constraint_fixed_width = Anchura Arreglada
-constraint_fixed_height = Altura Arreglada
-constraint_fixed_size = Tamaño Arreglado
-border = Acolchado de los bordes:
-border_tooltip = Espacio entre cada cuadro y el borde de la hoja de sprites
+constraint_fixed_cols = Fijo # of Columns
+constraint_fixed_rows = Fijo # of Rows
+constraint_fixed_width = Ancho Fijo
+constraint_fixed_height = Altura Fija
+constraint_fixed_size = Tamaño Fijo
+border = Margen de los bordes:
+border_tooltip = Espacio entre cada frame y el borde de la hoja de sprites
 shape = Espaciado:
 shape_tooltip = <<<END
-Espacio entre cada fotograma en la hoja de sprites
-(a.k.a "Acolchado de la forma")
+Espacio inter fotograma en la hoja de sprites
+(mejor conocido como "Shape Padding")
 END
-inner = Acolchado interior:
+inner = Margen interior:
 inner_tooltip = Espacio extra en los bordes del marco
 trim_sprite = Recortar Sprite
 trim_sprite_tooltip = Recorta todo el sprite antes de que sus fotogramas se incluyan en la hoja de sprites
-trim = Recortar
-trim_tooltip = Recorta cada marco por separado
-trim_by_grid = Por la Cuadricula
-trim_by_grid_tooltip = Recorta por los límites de la cuadrícula en lugar de píxel a píxel
+trim = Recortar Cels
+trim_tooltip = Recorta cada Cel por separado
+trim_by_grid = Por Grilla
+trim_by_grid_tooltip = Recorta por los límites de la grilla en lugar de píxel a píxel
 extrude = Extruir
-extrude_tooltip = Añade un borde a cada cuadro duplicando los píxeles de sus bordes
+extrude_tooltip = Añade un borde a cada frame duplicando los píxeles de sus bordes
 merge_dups = Fusionar Duplicados
 merge_dups_tooltip = Los marcos similares pueden utilizar la misma área rectangular de la hoja de sprites
-ignore_empty = Ignorar Vacios
+ignore_empty = Ignorar Vacíos
 ignore_empty_tooltip = No incluir marcos vacíos/transparentes en la hoja de sprites
 layers = Capas:
-split_layers = Dividir Capas
-split_layers_tooltip = Genera un sprite para cada capa
-split_tags = Dividir Etiquetas
-split_tags_tooltip = Genera un sprite para cada etiqueta
-frames = Cuadros:
+split_layers = Separar Capas
+split_layers_tooltip = Genera tiras de fotogramas para cada capa
+split_tags = Separar Etiquetas
+split_tags_tooltip = Genera tiras de fotogramas para cada etiqueta
+frames = Frames:
 output_file = Archivo de Salida
 json_data = Datos JSON
 json_data_hash = Hash
-json_data_array = Matriz
+json_data_array = Vector
 meta = Meta:
 meta_layers = Capas
 meta_tags = Etiquetas
-meta_slices = Piezas
+meta_slices = Recortes
 data_filename_format = Nombre de Archivo de Datos:
 data_filename_format_tooltip = <<<END
 Cada fotograma en los datos JSON contendrá un nombre de archivo 
-(cadena que los identifica), este campo describe cómo construir cada fotograma. 
+(cadena que los identifica), este campo describe cómo construir cada frame. 
 Puede utilizar marcas especiales como {layer}, {frame}, {tag}, {tagframe}, etc.
 END
 preview = Previsualizar
-open_sprite_sheet = Abrir hoja de Sprite
+open_sprite_sheet = Abrir Hoja de Sprite
 export = &Exportar
 cancel = &Cancelar
 generating = Generando...
@@ -670,19 +658,19 @@ generating = Generando...
 [file_selector]
 go_back_button_tooltip = Ir atras...
 go_forward_button_tooltip = Ir adelante...
-go_up_button_tooltip = Ir a Inicio
+go_up_button_tooltip = Ir a carpeta padre
 new_folder_button_tooltip = Nueva Carpeta
 list_view_button_tooltip = Vista de Lista
-small_icon_view_button_tooltip = Vista de Iconos Pequeños
-big_icon_view_button_tooltip = Vista de Iconos Grandes
+small_icon_view_button_tooltip = Vista de Íconos Pequeños
+big_icon_view_button_tooltip = Vista de Íconos Grandes
 file_name = Nombre del archivo:
 file_type = Tipo de archivo:
 pinned_folders = Carpetas ancladas
 recent_folders = Carpetas recientes
 
 [filters]
-selected_cels = Celdas Seleccionadas
-selected_cels_tooltip = Aplicar a la selección activa en la línea de tiempo
+selected_cels = Cels Seleccionadas
+selected_cels_tooltip = Aplicar a la selección activa en la timeline
 all_cels = Todo
 all_cels_tooltip = Aplicar a todos los cels del sprite
 
@@ -690,8 +678,8 @@ all_cels_tooltip = Aplicar a todos los cels del sprite
 load = Cargar
 
 [frame_properties]
-title = Propiedades de Cuadro
-frame_number = Número de Cuadro:
+title = Propiedades de Frame
+frame_number = Número de Frame:
 duration = Duración (milisegundos):
 
 [general]
@@ -709,7 +697,7 @@ END
 reset = Reestablecer
 
 [gif_options]
-title = Opciones del GIF
+title = Opciones GIF
 general_options = Opciones generales:
 interlaced = &Entrelazado
 animation_loop = Animación en &Bucle
@@ -717,11 +705,11 @@ ok = &OK
 cancel = &Cancelar
 
 [goto_frame]
-title = Ir al cuadro
-frame_or_tags = Número de cuadro o nombre de la etiqueta:
+title = Ir al frame
+frame_or_tags = Número de frame o nombre de la etiqueta:
 
 [grid_settings]
-title = Ajustes de la rejilla
+title = Ajustes de la Grilla
 x = X:
 y = Y:
 width = Anchura:
@@ -747,15 +735,15 @@ new_version_available = Nuevo {0} v{1} disponible!
 [import_sprite_sheet]
 title = Importar hoja de Sprite
 type = Tipo:
-tiles = Cuadriculas:
+tiles = Cuadrículas:
 x = X:
 y = Y:
-width = Anchura:
+width = Ancho:
 height = Altura:
-padding = Acolchado
+padding = Margen
 horizontal_padding = Horizontal:
 vertical_padding = Vertical:
-partial_tiles = Incluir azulejos parciales en los bordes inferiores/derechos
+partial_tiles = Incluir Tiles parciales en los bordes inferiores/derechos
 import = &Importar
 cancel = &Cancelar
 
@@ -770,14 +758,14 @@ shading = Sombreado
 same_in_all_tools = Igual en todas las herramientas
 
 [jpeg_options]
-title = Opciones de JPEG
+title = Opciones JPEG
 quality = Calidad:
 
 [keyboard_shortcuts]
 title = Atajos de teclado
 import = &Importar
 export = &Exportar
-reset = &reiniciar
+reset = &Reiniciar
 section_menus = Menu
 section_commands = Comandos
 section_tools = Herramientas
@@ -785,7 +773,7 @@ section_action_modifiers = Modificadores de Acción
 section_mouse_wheel = Rueda del Mouse
 default_wheel_behavior = Predeterminado
 custom_wheel_behavior = Personalizado
-slide_as_wheel = Interpretar el deslizamiento de dos dedos en el Trackpad como rueda del ratón
+slide_as_wheel = Interpretar el deslizamiento de dos dedos en el Trackpad como rueda del mouse
 ok = &OK
 cancel = &Cancelar
 
@@ -842,7 +830,7 @@ edit_shift_left = Izquierda (&L)
 edit_shift_right = Derecha (&R)
 edit_shift_up = Arriba (&U)
 edit_shift_down = Abajo (&D)
-edit_new_brush = Nuevo Pincel (&B)
+edit_new_brush = Nuevo Brocha (&B)
 edit_new_sprite_from_selection = &Nuevo Sprite Desde Selección
 edit_replace_color = R&eemplazar Color...
 edit_invert_color = &Invertir...
@@ -851,7 +839,7 @@ edit_adjustments_brightness_contrast = &Brillo/Contraste...
 edit_adjustments_hue_saturation = Tono/Saturación (&H)...
 edit_adjustments_color_curve = Curva de &Color...
 edit_fx = F&X
-edit_fx_outline = &Esquema
+edit_fx_outline = &Contorno
 edit_fx_convolution_matrix = Convolución de &Matriz...
 edit_fx_despeckle = &Despeckle (Median Filter)...
 edit_insert_text = Insertar Texto
@@ -872,11 +860,11 @@ sprite_rotate = R&otar
 sprite_rotate_180 = &180
 sprite_rotate_90cw = &90 a la Izquierda
 sprite_rotate_90ccw = 90 &a la Derecha
-sprite_flip_canvas_horizontal = Rotar Lienzo &Horizontal
-sprite_flip_canvas_vertical = Rotar Lienzo &Vertical
+sprite_flip_canvas_horizontal = Invertir Lienzo &Horizontal
+sprite_flip_canvas_vertical = Invertir Lienzo &Vertical
 sprite_crop = Rec&ortar
 sprite_trim = Ajustar (&T)
-layer = &Lienzo
+layer = &Capa
 layer_properties = &Propiedades...
 layer_visible = &Visible
 layer_lock_layers = Bloquear Capa (&K)
@@ -892,31 +880,31 @@ layer_background_from_layer = Fondo de la Capa (&B)
 layer_layer_from_background = Capa desde Fondo (&L)
 layer_duplicate = &Duplicar
 layer_merge_down = Combinar hacia Abajo (&M)
-layer_flatten = Aplanar (&F)
-layer_flatten_visible = Aplanar Vi&sibles
+layer_flatten = Fusionar todas (&F)
+layer_flatten_visible = Fusionar Vi&sibles
 frame = Cuad&ros
-frame_properties = &Propiedades de Cuadro...
-frame_cel_properties = Propiedades de &Celda...
-frame_new_frame = &Nuevo Cuadro
-frame_new_empty_frame = Nuevo Cuadro Vacío (&E)
-frame_duplicate_cels = &Duplicar Celda(s)
-frame_duplicate_linked_cels = Duplicar Celdas(s) Conectadas (&L)
-frame_delete_frame = Borrar Cuadro
+frame_properties = &Propiedades de Frame...
+frame_cel_properties = Propiedades de &Cel...
+frame_new_frame = &Nuevo Frame
+frame_new_empty_frame = Nuevo Frame Vacío (&E)
+frame_duplicate_cels = &Duplicar Cel(s)
+frame_duplicate_linked_cels = Duplicar Cel(s) Conectadas (&L)
+frame_delete_frame = Borrar Frame
 frame_tags = E&tiquetas
 frame_tags_tag_properties = &Propiedades de Etiqueta...
 frame_tags_new_tag = Nueva e&tiqueta
 frame_tags_delete_tag = Borrar Etiqueta (&D)
 frame_jump_to = Saltar a (&J)
-frame_jump_to_first_frame = Primer Cuadro (&F)
-frame_jump_to_previous_frame = Cuadro Anterior (&P)
-frame_jump_to_next_frame = Próximo Cuadro (&N)
-frame_jump_to_last_frame = Último Cuadro (&L)
-frame_jump_to_first_frame_in_tag = Primer Cuadro en Etiqueta
-frame_jump_to_last_frame_in_tag = Último Cuadro en Etiqueta
-frame_go_to_frame = Ir a Cuadro (&G)
+frame_jump_to_first_frame = Primer Frame (&F)
+frame_jump_to_previous_frame = Frame Anterior (&P)
+frame_jump_to_next_frame = Próximo Frame (&N)
+frame_jump_to_last_frame = Último Frame (&L)
+frame_jump_to_first_frame_in_tag = Primer Frame en Etiqueta
+frame_jump_to_last_frame_in_tag = Último Frame en Etiqueta
+frame_go_to_frame = Ir a Frame (&G)
 frame_play_animation = Reproducir Animación (&P)
-frame_constant_frame_rate = Ritmo Constante de Cuadros  
-frame_reverse_frames = Cuadros Inversos (&V)
+frame_constant_frame_rate = Ritmo Constante de Frames  
+frame_reverse_frames = Frames en Reversa (&V)
 select = Seleccionar
 select_all = Seleccionar &Todo
 select_deselect = &Deseleccionar
@@ -935,20 +923,20 @@ view_show_extras = &Extras
 view_show = Mo&strar
 view_show_layer_edges = Bordes de Capa (&L)
 view_show_selection_edges = &Selección de Bordes
-view_show_grid = Cuadrícula (&G)
+view_show_grid = Grilla (&G)
 view_show_auto_guides = Guías &Automáticas
-view_show_slices = Sl&ices
-view_show_pixel_grid = Cuadrícula de &Pixel
+view_show_slices = Recortes (&i)
+view_show_pixel_grid = Grilla de &Pixel
 view_show_brush_preview = &Brush Preview
-view_grid = &Cuadrícula
-view_grid_settings = Configuración de Cuadrícula
-view_grid_selection_as_grid = Selecc&ión como Cuadrícula
-view_grid_snap_to_grid = Encajar en Cuadrícula (&S)
-view_tiled_mode = Modo &Mosaico
+view_grid = &Grilla
+view_grid_settings = Configuración de Grilla
+view_grid_selection_as_grid = Selecc&ión como Grilla
+view_grid_snap_to_grid = Encajar en Grilla (&S)
+view_tiled_mode = &Modo Tiled
 view_tiled_mode_none = &Desactivado
-view_tiled_mode_both = Mosaico en &Ambos Ejes
-view_tiled_mode_x = Mosaico en &Eje X
-view_tiled_mode_y = Mosaico en &Eje Y
+view_tiled_mode_both = Tiled en &Ambos Ejes
+view_tiled_mode_x = Tiled en &Eje X
+view_tiled_mode_y = Tiled en &Eje Y
 view_symmetry_options = Opciones de Simetría
 view_set_loop_section = Seleccionar Sección de Duplicado (&L)
 view_show_onion_skin = Mostrar &Piel de Cebolla
@@ -985,7 +973,7 @@ default_new_layer_name = Nueva Capa
 [new_sprite]
 title = Nuevo Sprite
 size = Tamaño:
-width = Anchura:
+width = Ancho:
 height = Altura:
 color_mode = Modo de Color:
 rgba = &RGB+Alfa
@@ -1032,8 +1020,8 @@ section_selection = Selección
 section_timeline = Timeline
 section_cursors = Cursores
 section_background = Fondo
-section_grid = Cuadrícula
-section_guides_and_slices = Guías &y Sectores
+section_grid = Grilla
+section_guides_and_slices = Guías &y Recortes
 section_undo = Deshacer
 section_theme = Tema
 section_extensions = Extensiones
@@ -1047,7 +1035,7 @@ gpu_acceleration = Aceleración de la GPU
 gpu_acceleration_tooltip = Marque esta opción para activar la aceleración por hardware
 show_menu_bar = Mostrar la barra de menú de Aseprite
 show_home = Mostrar la pestaña de Inicio cuando se inicia Aseprite
-expand_menu_bar_items_on_mouseover = Ampliar los elementos de la barra de menús al pasar el ratón por encima
+expand_menu_bar_items_on_mouseover = Ampliar los elementos de la barra de menús al pasar el mouse por encima
 expand_menu_bar_items_on_mouseover_tooltip = <<<END
 Marque esta opción para obtener 
 el comportamiento de los menús antiguos.
@@ -1069,15 +1057,15 @@ END
 30_minutes = 30 Minutos
 1_hour = 1 Hora
 4_hours = 4 Horas
-8_hours = 8 Horax
-keep_edited_sprite_data = Mantener los datos de los sprites editados para...
+8_hours = 8 Horas
+keep_edited_sprite_data = Mantener los datos de los sprites editados por...
 keep_edited_sprite_data_tooltip = <<<END
 Con esta opción puede reabrir los documentos editados 
 después de cerrar el programa durante el número de días especificado.
 END
-1_day = 1 Dia
-2_days = 2 Dias
-3_days = 3 Dias
+1_day = 1 Día
+2_days = 2 Días
+3_days = 3 Días
 1_week = 1 Semana
 2_weeks = 2 Semanas
 1_month = 1 Mes
@@ -1086,24 +1074,25 @@ show_full_path_tooltip = <<<END
 Desmarque esta opción si prefiere ocultar la ruta completa 
 en la interfaz de usuario (es útil para los streamings)
 END
-keep_closed_sprite_on_memory = Mantener el sprite cerrado en la memoria para...
+keep_closed_sprite_on_memory = Mantener el sprite cerrado en la memoria por...
 keep_closed_sprite_on_memory_tooltip = <<<END
 Cuando se cierra un sprite, se mantiene en la memoria por si 
-acaso se ha cerrado el sprite por error, por lo que se puede 
-"deshacer" la acción de cierre utilizando la opción de menú 
-"Archivo > Reabrir archivo cerrado".
+acaso se ha cerrado el sprite por error, por lo que se puede
+reabrir el mismo mediante "Archivo > Reabrir Archivo Cerrado",
+con el plus que la historia de la acción "deshacer" del mismo
+se mantiene intacta.
 END
 default_extension_for = Extensión por defecto para:
 save_default_extension = Archivo > Guardar:
-export_image_default_extension = Archivo > Exportar (imagen estatica):
+export_image_default_extension = Archivo > Exportar (imagen estática):
 export_animation_default_extension = Archivo > Exportar (animación):
-export_sprite_sheet_default_extension = Archivo > Exportar hoja de Sprite:
+export_sprite_sheet_default_extension = Archivo > Exportar Hoja de Sprite:
 recent_files = Artículos recientes:
 recent_files_tooltip = Número de archivos y carpetas recientes
 clear_recent_files = Limpiar
 clear_recent_files_tooltip = Borrar la lista de archivos y carpetas recientes
 locate_file = Localizar el archivo de configuración
-locate_crash_folder = Localizar la carpeta de crasheos
+locate_crash_folder = Localizar la carpeta de crashes
 tablet_api_windows_pointer = API de puntero de Windows 8/10 (Windows Ink)
 tablet_api_wintab_system = Wintab
 tablet_api_wintab_direct = Wintab (procesamiento directo de paquetes)
@@ -1121,7 +1110,7 @@ En la herramienta Lápiz puede dibujar líneas rectas
 usando Shift+clic, con esta opción marcada verá la 
 vista previa inmediatamente cuando se pulse la tecla Shift.
 END
-discard_brush = Descartar el pincel personalizado cuando se utiliza el cuentagotas
+discard_brush = Descartar la brocha personalizada cuando se utiliza el cuentagotas
 right_click = Clic Derecho:
 editor_selection = Selección
 auto_opaque = Ajustar el modo opaco/transparente automáticamente
@@ -1144,66 +1133,66 @@ move_edges = Permitir mover los bordes de selección
 move_edges_tooltip = <<<END
 Marque esta opción si desea poder arrastrar 
 sólo los bordes de la selección cuando el 
-ratón esté por encima de ellos.
+cursor esté encima de esta.
 END
-modifiers_disable_handles = Desactivar las manijas de transformación cuando se presionan modificadores de teclas
+modifiers_disable_handles = Desactivar los manipuladores de transformación cuando se presionan modificadores de teclas
 modifiers_disable_handles_tooltip = <<<END
 Si pulsa las teclas Shift/Ctrl/Alt, 
-los tiradores para transformar la 
+los manipuladores para transformar la 
 selección se desactivarán temporalmente.
 END
 move_on_add_mode = Mover la selección en el modo Añadir
 move_on_add_mode_tooltip = <<<END
 En el modo "Añadir a la selección", podemos mover 
-la selección cuando el ratón está dentro de ella.
+la selección cuando el cursor está dentro de ella.
 END
-select_tile_with_double_click = Seleccione una baldosa de la cuadrícula con un doble clic
+select_tile_with_double_click = Seleccione una baldosa de la grilla con un doble clic
 force_rotsprite = Forzar el RotSprite incluso para ángulos rectos/derechos
-multicel_when_layers_or_frames = Transformación de los cuadros en las capas o fotogramas seleccionados en la línea de tiempo
+multicel_when_layers_or_frames = Transformación de los cels en las capas o frames seleccionados en la timeline
 multicel_when_layers_or_frames_tooltip = <<<END
 Al transformar la selección, se transformarán todos 
-los cels seleccionados en la línea de tiempo. 
-Con esta opción, si selecciona varias capas o fotogramas, 
-la transformación se aplicará a todos los fotogramas de 
-las capas o fotogramas seleccionados. Sin esta opción, 
+los cels seleccionados en la timeline. 
+Con esta opción, si selecciona varias capas o frames, 
+la transformación se aplicará a todos los cels de 
+las capas o frames seleccionados. Sin esta opción, 
 sólo se transformarán varios cels si se seleccionan 
-explícitamente varios cels en la línea de tiempo.
+explícitamente varios cels en la timeline.
 END
-autotimeline = Mostrar automáticamente la línea de tiempo
+autotimeline = Mostrar automáticamente la timeline
 autotimeline_tooltip = <<<END
-Mostrar la línea de tiempo automáticamente 
-cuando se añade un nuevo fotograma o capa.
+Mostrar la timeline automáticamente 
+cuando se añade un nuevo frame o capa.
 END
 rewind_on_stop = Rebobinar al parar
 rewind_on_stop_tooltip = <<<END
 El botón 'Stop' debería rebobinar la animación 
 en el punto en que se inició.
 END
-default_first_frame = Primer Fotograma Predeterminado:
-ui_mouse_cursor = Cursor de Mouse en Interfaz
-native_cursor = Usar cursores de Mouse nativos
+default_first_frame = Primer frame Predeterminado:
+ui_mouse_cursor = Cursor de mouse en interfaz
+native_cursor = Usar cursores de mouse nativos
 cursor_scale_label = Escala de Cursor de Mouse:
 painting_cursors = Cursores de Pintura
-crosshair_type = Tipo de retícula:
-simple_crosshair = Cruceta simple
-crosshair_on_sprite = Cruceta en el Sprite
+crosshair_type = Tipo de cruz del cursor:
+simple_crosshair = Cruz simple
+crosshair_on_sprite = Cruz en el Sprite
 brush_preview = Vista previa de la Brocha:
 brush_preview_none = Ninguna
-brush_preview_edges = Solo esquinas
+brush_preview_edges = Solo Bordes
 brush_preview_full = Vista Previa Completa
-brush_preview_fullall = Vista Previa completa con Todo Tools
-brush_preview_fullnedges = Vista previa completa y bordes
-cursor_color_type = Color de la retícula y de los bordes del pincel:
+brush_preview_fullall = Vista Previa Completa todas las Herraminentas
+brush_preview_fullnedges = Vista Previa Completa y Bordes
+cursor_color_type = Color de la cruz y de los bordes de la brocha:
 cursor_neg_bw = Negativo en blanco y negro
 cursor_specific_color = Color específico
 bg_checked = Fondo "de ajedrez"
 bg_size = Tamaño:
 bg_apply_zoom = Aplicar zoom
 bg_colors = Colores:
-grid_visible = Rejilla visible
+grid_visible = Grilla visible
 grid_x = X:
 grid_y = Y:
-grid_width = Anchura:
+grid_width = Ancho:
 grid_height = Altura:
 grid_color = Color:
 grid_opacity = Opacidad:
@@ -1211,24 +1200,24 @@ grid_auto = Auto
 grid_pixel_grid_visible = Rejilla de píxeles visibles
 grid_pixel_grid_color = Color:
 grid_pixel_grid_opacity = Opacidad:
-guides = Guias
-slices = Pedazos
+guides = Guías
+slices = Recortes
 layer_edges_color = Color de los bordes de la capa:
-auto_guides_color = Auto-Guías Color:
-default_slice_color = Color por defecto:
+auto_guides_color = Color de Auto-Guías:
+default_slice_color = Color por Defecto:
 undo = Deshacer
 undo_show_tooltip = Mostrar el tooltip de Deshacer
 undo_size_limit = Limite de Deshacer:
 undo_size_limit_tooltip = <<<END
-Limita el uso de la memoria
-para deshacer información por píxeles.
+Limita el uso de la memoria destinada a la
+historia "deshacer" de cada sprite.
 Especificado en MegaBytes (MB).
 END
 undo_mb = MB
-undo_goto_modified = Ir a la Capa/Cuadro Modificada
+undo_goto_modified = Ir a la Capa/Frame Modificada
 undo_goto_modified_tooltip = <<<END
 Cuando esté habilitado cada vez que deshagas y rehagas
-la capa y cuadro activo serán modificados para
+la capa y frame activo serán modificados para
 enfocar los cambios.
 END
 undo_allow_nonlinear_history = Permitir historial no li&neal
@@ -1238,7 +1227,7 @@ overwrite_files_on_export_alert = Mostrar advertencia al sobrescribir archivos e
 overwrite_files_on_export_sprite_sheet_alert = Mostrar advertencia al sobrescribir archivos en la hoja de Sprite de exportación
 image_format_alerts = Mostrar las opciones al guardar los archivos:
 advanced_mode_alert = Mostrar alerta cuando entramos en el Modo Avanzado
-invalid_fg_bg_color_alert = Mostrar alerta cuando se dibuja con el índice fuera de los límites de la paleta
+invalid_fg_bg_color_alert = Mostrar alerta cuando se dibuja con índice fuera de los límites de la paleta
 run_script_alert = Mostrar alerta cuando intentamos ejecutar un script
 reset_alerts = Restablecer todos los diálogos de alerta
 color_management = Administracion de Color
@@ -1275,10 +1264,10 @@ new_blend = Nuevo método de mezcla de capas
 new_render_engine = Nuevo motor de renderizado para el editor de sprites
 native_clipboard = Utilizar el portapapeles nativo
 native_file_dialog = Utilizar el diálogo de archivos nativos
-one_finger_as_mouse_movement = Interpretar un dedo como movimiento del ratón
+one_finger_as_mouse_movement = Interpretar un dedo como movimiento del mouse
 one_finger_as_mouse_movement_tooltip = <<<END
 Sólo para Windows 8/10 Pointer API: 
-Interpreta un dedo como movimiento del ratón 
+Interpreta un dedo como movimiento del mouse 
 y dos dedos como paneo/desplazamiento. 
 Desmarque esta opción para utilizar el comportamiento
 antiguo: un dedo se desplaza/desplaza.
@@ -1309,7 +1298,7 @@ bg_color = Color de Fondo:
 title = Paleta de Sprite
 new_palette = Cree una nueva paleta con un número determinado de colores (o menos):
 replace_palette = Sustituir la paleta actual
-replace_range = Sustituir la gama actual
+replace_range = Sustituir el rango de colores seleccionado
 alpha_channel = Crear entradas con componente alfa
 
 [palette_popup]
@@ -1322,11 +1311,11 @@ palette_size = Tamaño de Paleta
 small_size = Tamaño Pequeño
 medium_size = Tamaño Mediano
 large_size = Tamaño Grande
-color_tint_shade_tone = Tinte de color/tono
+color_tint_shade_tone = Color Tinte/Sombra/Tono
 color_spectrum = Espectro de colores
 rgb_color_wheel = Rueda de color RGB
 ryb_color_wheel = Rueda de colores RYB
-normal_map_color_wheel = Rueda de color del mapeado normal
+normal_map_color_wheel = Rueda de color de mapeado normal
 load_palette = Cargar Paleta
 save_palette = Guardar Paleta
 load_default_palette = Cargar Paleta por defecto
@@ -1353,7 +1342,7 @@ recover_sprite = Recuperar Sprite
 recover_n_sprites = Recuperar {} Sprite(s)
 delete = Borrar
 refresh = Refrescar
-raw_images_as_frames = Imagenes RAW como Fotogramas
+raw_images_as_frames = Imagenes RAW como Frames
 raw_images_as_layers = Imagenes RAW como Capas
 loading = cargando...
 crash_sessions = Sesiones Crasheadas
@@ -1362,7 +1351,7 @@ incompatible = [PUEDE SER INCOMPATIBLE CON v{1}] {0}
 
 [replace_color]
 from = Desde:
-to = Para:
+to = Hasta:
 tolerance = Tolerancia:
 
 [script_access]
@@ -1370,7 +1359,7 @@ title = Seguridad
 script_label = El siguiente script:
 file_label = quiere acceder al siguiente archivo:
 command_label = quiere ejecutar el siguiente comando:
-dont_show_for_this_access = No mostrar esta alerta la proxima vez que ejecute el script
+dont_show_for_this_access = No mostrar esta alerta la próxima vez que ejecute el script
 dont_show_for_this_script = Dar confianza al ejecutar el script
 allow_execute_access = Permitir acceso a ejecutar
 allow_write_access = Permitir acceso a escritura
@@ -1398,37 +1387,37 @@ text = Seleccionar Archivo...
 browse = ...
 
 [send_crash]
-title = Reportar Cierre Inesperado
-send_file = Porfavor, mande el siguiente archivo:
+title = Reportar Cierre Inesperado (Crash)
+send_file = Por favor, mande el siguiente archivo:
 to_email = A este correo:
-explaining = Explica como se produjo el cierre inesperado
+explaining = Explica como se produjo el crash
 using_dev_ver = Estas usando una version de desarrollador.
-open_dmp_file = Abre el archivo para hacer debug a esta compilación:
+open_dmp_file = Abre el archivo para depurar esta compilación:
 do_it_later = Hacerlo mas tarde
-delete_file = Borra, el archivo, ya lo envie
+delete_file = Borrar el archivo, ya lo envié
 
 [slice_popup_menu]
-properties = Propiedades de Piezas...
-delete = Borrar Pieza
+properties = Propiedades de Recortes...
+delete = Borrar Recortes
 
 [slice_properties]
-title = Propiedades de Piezas
-name = Nombre de Pedazo
+title = Propiedades de Recortes
+name = Nombre de Recorte
 user_data_tooltip = Datos de Usuario
-bounds = Límites:
-center = 9 Piezas
+bounds = Rectágulo:
+center = 9-Recortes
 pivot = Pivote
 x = X
 y = Y
-width = Anchura
+width = Ancho
 height = Altura
 
 [sprite_properties]
-title = Prpiedades de Sprite
+title = Propiedades de Sprite
 filename = Nombre de Archivo:
 type = Tipo:
 size = Tamaño:
-frames = Fotogramas:
+frames = Frames:
 advanced = Avanzado
 transparent_color = Color Transparente:
 transparent_color_tooltip = <<<END
@@ -1446,8 +1435,8 @@ convert_color_profile = Convertir
 
 [sprite_size]
 title = Tamaño del sprite
-pixels = Pixéles:
-width = Anchura:
+pixels = Píxeles:
+width = Ancho:
 width_px_tooltip = Nuevo ancho para el sprite (en píxeles)
 width_perc_tooltip = <<<END
 Nuevo ancho para el sprite 
@@ -1459,23 +1448,23 @@ height_perc_tooltip = <<<END
 Nueva altura para el sprite 
 Porcentaje de la altura actual.
 END
-lock_ratio = Bloquear Relacion
+lock_ratio = Bloquear Relación
 percentage = Porcentaje:
 interpolation = Entrelazado:
 method = Método:
 
 [svg_options]
 title = Opciones de SVG
-pixel_scale = Escala de Pxeles:
+pixel_scale = Escala de Píxeles:
 
 [tab_popup_menu]
 close = &Cerrar
 
 [tag_properties]
-title = Propiedades de Tag
+title = Propiedades de Etiqueta
 name = Nombre:
 from = Desde:
-to = Para:
+to = Hasta:
 color = Color:
 ani_dir = Dirección Animación:
 
@@ -1485,22 +1474,22 @@ bits_per_pixel = Bits por píxel
 compress = Comprimir
 
 [timeline_conf]
-position = Posicion:
+position = Posición:
 left = Izquierda
 right = Derecha
 bottom = Abajo
-frame_header = Cabecera del fotograma:
-first_frame = Primer Fotograma:
+frame_header = Frame de Cabecera:
+first_frame = Primer Frame:
 thumbnails = Miniaturas
 thumbnail_size = Tamaño de Miniaturas:
 overlay_size = Tamaño de la superposición:
 onion_skin = Piel de Cebolla:
-merge_frames = Fusionar Fotogramas
+merge_frames = Fusionar Frames
 red_blue_tint = Tinte rojo/azul
 reset = Reiniciar
 opacity = Opacidad:
-opacity_step = PAsos de Opacidad:
-loop_tags = Bucle a través de los marcos de las etiquetas
+opacity_step = Paso de Opacidad:
+loop_tags = Bucle a través de los frames de las etiquetas
 current_layer = Sólo la capa actual
 behind_sprite = Detrás del sprite
 behind_sprite_toolip = <<<END
@@ -1512,16 +1501,16 @@ in_front = Frente al sprite
 in_front_toolip = Para todo tipo de capas (fondo y transparentes)
 
 [tools]
-rectangular_marquee = Rectangular Marquee Tool
+rectangular_marquee = Selección Rectangular
 selection_tooltip = <<<END
 * Botón izquierdo: reemplazar/añadir a la selección actual.
 * Botón derecho: eliminar de la selección actual.
 END
-elliptical_marquee = Marquesina Elíptica
-lasso_tool = Lazo
+elliptical_marquee = Selección Elíptica
+lasso_tool = Selección Lazo
 polygonal_lasso = Lazo Poligonal
 magic_wand = Varita Mágica
-pencil = Lapiz
+pencil = Lápiz
 spray = Spray
 eraser = Borrador
 eraser_tooltip = <<<END
@@ -1533,17 +1522,17 @@ eyedropper = CuentaGotas
 zoom = Lupa
 hand = Mano
 move = Transformar
-slice = Cuchilla
+slice = Recorte
 paint_bucket = Balde de Pintura
 gradient = Gradiente
-line = Linea
+line = Línea
 curve = Curva
-rectangle = Rectangulo
-filled_rectangle = Rectangulo Lleno
+rectangle = Rectángulo
+filled_rectangle = Rectángulo Lleno
 ellipse = Elipse
-filled_ellipse = Elipse Lleno
-contour = Contornos
-polygon = Poligono
+filled_ellipse = Elipse Llena
+contour = Contorno
+polygon = Polígono
 blur = Blur
 jumble = Jumble
 shortcut = Acceso Directo: {0}
@@ -1551,25 +1540,25 @@ preview_hide = Esconder Vista Previa
 preview_show = Mostrar Vista Previa
 
 [undo_history]
-title = Deshacer Historial
+title = Historial Deshacer
 
 [user_data]
 user_data = Datos de Usuario:
 color = Color:
 
 [webp_options]
-title = Opciones de WebP
+title = Opciones WebP
 save_as = Guardar como:
 animation_loop = Animación en Bucle
 type = Tipo:
 simple_webp = Simple: Una buena compresión sin pérdidas
 lossless_webp = WebP sin pérdidas
-compression = Compresion:
+compression = Compresión:
 image_hint = Sugerencia de imagen:
 image_hint_default = Predeterminado
 image_hint_picture = Imagen
 image_hint_photo = Foto
-image_hint_graph = Grafico
+image_hint_graph = Gráfico
 lossy_webp = WebP con pérdidas
 quality = Calidad:
 image_preset = Preajuste de imagen:
@@ -1577,12 +1566,12 @@ image_preset_default = Predeterminado
 image_preset_picture = Imagen
 image_preset_photo = Foto
 image_preset_drawing = Dibujo
-image_preset_icon = Icono
+image_preset_icon = Ícono
 image_preset_text = Texto
 
 [symmetry]
-toggle = Alternar la simetría
-toggle_horizontal = Alternar la simetría horizontal
-toggle_vertical = Alternar la simetría vertical
+toggle = Activar/Desactivar simetría
+toggle_horizontal = Activar/Desactivar simetría horizontal
+toggle_vertical = Activar/Desactivar simetría vertical
 show_options = Opciones de simetría
 reset_position = Restablecer la simetría al centro


### PR DESCRIPTION
Varias líneas cambiadas.
Los cambios más significativos fueron:

- Línea de Tiempo —> Timeline
- Fotogramas (refiriendo a frames) —> Frames
- Cuadros —> Frames
- Fotograma en contexto de Hoja de Sprite se dejó en Fotograma (otras posibilidades: Muestra, Figura, Imagen)
- Celdas —> Cels  (las Cels NO son Celdas de una tabla, una Cel -en Aseprite- posee una imagen y una posición de imagen específica)
- Slices —> Recortes (podría ser reemplazada por otra palabra: Porción, Área, Corte, Sector, Rebanada)
- Mosaicos —> Tiles
- Cuadrícula—> Grilla
- Retícula —> Cruz del Cursor

Estos cambios podrán ser cambiados nuevamente por sugerencia del desarrollador principal de Aseprite.